### PR TITLE
refactor: Update import paths to use correct package name

### DIFF
--- a/cmd/cli/commands/install/install.go
+++ b/cmd/cli/commands/install/install.go
@@ -3,9 +3,9 @@ package install
 import (
 	"fmt"
 
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/commands/install/wizard"
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/terminal"
-	"github.com/ethpandaops/contributoor-installer-test/internal/service"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/commands/install/wizard"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/terminal"
+	"github.com/ethpandaops/contributoor-installer/internal/service"
 	"github.com/rivo/tview"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"

--- a/cmd/cli/commands/install/wizard/install_wizard.go
+++ b/cmd/cli/commands/install/wizard/install_wizard.go
@@ -1,9 +1,9 @@
 package wizard
 
 import (
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/terminal"
-	"github.com/ethpandaops/contributoor-installer-test/internal/display"
-	"github.com/ethpandaops/contributoor-installer-test/internal/service"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/terminal"
+	"github.com/ethpandaops/contributoor-installer/internal/display"
+	"github.com/ethpandaops/contributoor-installer/internal/service"
 	"github.com/rivo/tview"
 	"github.com/sirupsen/logrus"
 )

--- a/cmd/cli/commands/install/wizard/step_finished.go
+++ b/cmd/cli/commands/install/wizard/step_finished.go
@@ -1,7 +1,7 @@
 package wizard
 
 import (
-	"github.com/ethpandaops/contributoor-installer-test/internal/display"
+	"github.com/ethpandaops/contributoor-installer/internal/display"
 	"github.com/rivo/tview"
 )
 

--- a/cmd/cli/commands/install/wizard/step_network.go
+++ b/cmd/cli/commands/install/wizard/step_network.go
@@ -3,8 +3,8 @@ package wizard
 import (
 	"fmt"
 
-	"github.com/ethpandaops/contributoor-installer-test/internal/display"
-	"github.com/ethpandaops/contributoor-installer-test/internal/service"
+	"github.com/ethpandaops/contributoor-installer/internal/display"
+	"github.com/ethpandaops/contributoor-installer/internal/service"
 	"github.com/rivo/tview"
 )
 

--- a/cmd/cli/commands/install/wizard/step_welcome.go
+++ b/cmd/cli/commands/install/wizard/step_welcome.go
@@ -3,7 +3,7 @@ package wizard
 import (
 	"fmt"
 
-	"github.com/ethpandaops/contributoor-installer-test/internal/display"
+	"github.com/ethpandaops/contributoor-installer/internal/display"
 )
 
 // WelcomeStep is the first step of the installation wizard.

--- a/cmd/cli/commands/start/start.go
+++ b/cmd/cli/commands/start/start.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/urfave/cli"
 
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/terminal"
-	"github.com/ethpandaops/contributoor-installer-test/internal/service"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/terminal"
+	"github.com/ethpandaops/contributoor-installer/internal/service"
 )
 
 func RegisterCommands(app *cli.App, opts *terminal.CommandOpts) {

--- a/cmd/cli/commands/stop/stop.go
+++ b/cmd/cli/commands/stop/stop.go
@@ -3,8 +3,8 @@ package stop
 import (
 	"fmt"
 
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/terminal"
-	"github.com/ethpandaops/contributoor-installer-test/internal/service"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/terminal"
+	"github.com/ethpandaops/contributoor-installer/internal/service"
 	"github.com/urfave/cli"
 )
 

--- a/cmd/cli/commands/update/update.go
+++ b/cmd/cli/commands/update/update.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/urfave/cli"
 
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/terminal"
-	"github.com/ethpandaops/contributoor-installer-test/internal/service"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/terminal"
+	"github.com/ethpandaops/contributoor-installer/internal/service"
 )
 
 // RegisterCommands registers the update command.
@@ -44,7 +44,7 @@ func updateContributoor(c *cli.Context, opts *terminal.CommandOpts) error {
 
 	log.WithField("version", configService.Get().Version).Info("Current version")
 
-	github := service.NewGitHubService("ethpandaops", "contributoor-test")
+	github := service.NewGitHubService("ethpandaops", "contributoor")
 
 	// Determine target version
 	var targetVersion string

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -6,11 +6,11 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/commands/install"
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/commands/start"
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/commands/stop"
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/commands/update"
-	"github.com/ethpandaops/contributoor-installer-test/cmd/cli/terminal"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/commands/install"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/commands/start"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/commands/stop"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/commands/update"
+	"github.com/ethpandaops/contributoor-installer/cmd/cli/terminal"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )

--- a/cmd/cli/terminal/shell.go
+++ b/cmd/cli/terminal/shell.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ethpandaops/contributoor-installer-test/internal/display"
+	"github.com/ethpandaops/contributoor-installer/internal/display"
 	"github.com/urfave/cli"
 )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   sentry:
-    image: ethpandaops/contributoor-test:${CONTRIBUTOOR_VERSION}
+    image: ethpandaops/contributoor:${CONTRIBUTOOR_VERSION}
     command: ["sentry", "--config", "/config/config.yaml"]
     volumes:
       - ${CONTRIBUTOOR_CONFIG_PATH}/config.yaml:/config/config.yaml:ro

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ethpandaops/contributoor-installer-test
+module github.com/ethpandaops/contributoor-installer
 
 go 1.23.4
 

--- a/install.sh
+++ b/install.sh
@@ -142,7 +142,7 @@ add_to_path() {
 
 setup_installer() {
     local temp_archive=$(mktemp)
-    local checksums_url="https://github.com/ethpandaops/contributoor-installer-test/releases/latest/download/checksums.txt"
+    local checksums_url="https://github.com/ethpandaops/contributoor-installer/releases/latest/download/checksums.txt"
     local checksums_file=$(mktemp)
     
     # Download checksums
@@ -200,16 +200,16 @@ setup_installer() {
 setup_docker_contributoor() {
     docker system prune -f >/dev/null 2>&1 || true
 
-    docker pull "ethpandaops/contributoor-test:${VERSION}" >/dev/null 2>&1 &
+    docker pull "ethpandaops/contributoor:${VERSION}" >/dev/null 2>&1 &
     spinner $!
     wait $!
     [ $? -ne 0 ] && fail "Failed to pull docker image"
-    success "Pulled docker image: ethpandaops/contributoor-test:${VERSION}"
+    success "Pulled docker image: ethpandaops/contributoor:${VERSION}"
 }
 
 setup_binary_contributoor() {
     local temp_archive=$(mktemp)
-    local checksums_url="https://github.com/ethpandaops/contributoor-test/releases/download/v${VERSION}/contributoor-test_${VERSION}_checksums.txt"
+    local checksums_url="https://github.com/ethpandaops/contributoor/releases/download/v${VERSION}/contributoor_${VERSION}_checksums.txt"
     local checksums_file=$(mktemp)
     
     # Download checksums
@@ -231,7 +231,7 @@ setup_binary_contributoor() {
     success "Downloaded contributoor"
     
     # Verify checksum
-    local binary_name="contributoor-test_${VERSION}_${PLATFORM}_${ARCH}.tar.gz"
+    local binary_name="contributoor_${VERSION}_${PLATFORM}_${ARCH}.tar.gz"
     local expected_checksum=$(grep "$binary_name" "$checksums_file" | cut -d' ' -f1)
     [ -z "$expected_checksum" ] && {
         rm -f "$checksums_file" "$temp_archive"
@@ -264,7 +264,7 @@ setup_binary_contributoor() {
 ###############################################################################
 
 get_latest_version() {
-    local release_info=$(curl -s "https://api.github.com/repos/ethpandaops/contributoor-test/releases/latest")
+    local release_info=$(curl -s "https://api.github.com/repos/ethpandaops/contributoor/releases/latest")
     [ $? -ne 0 ] && fail "Failed to check for latest version"
     
     local version=$(echo "$release_info" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4 | sed 's/^v//')
@@ -275,7 +275,7 @@ get_latest_version() {
 
 validate_version() {
     local version=$1
-    local releases=$(curl -s "https://api.github.com/repos/ethpandaops/contributoor-test/releases")
+    local releases=$(curl -s "https://api.github.com/repos/ethpandaops/contributoor/releases")
     [ $? -ne 0 ] && fail "Failed to check available versions"
 
     if ! echo "$releases" | grep -q "\"tag_name\": *\"v\{0,1\}${version}\""; then
@@ -375,10 +375,10 @@ main() {
     success "Using path: $CONTRIBUTOOR_PATH"
 
     # Setup URLs
-    INSTALLER_BINARY_NAME="contributoor-installer-test_${PLATFORM}_"
+    INSTALLER_BINARY_NAME="contributoor-installer_${PLATFORM}_"
     [ "$ARCH" = "amd64" ] && INSTALLER_BINARY_NAME="${INSTALLER_BINARY_NAME}x86_64" || INSTALLER_BINARY_NAME="${INSTALLER_BINARY_NAME}${ARCH}"
-    INSTALLER_URL="https://github.com/ethpandaops/contributoor-installer-test/releases/latest/download/${INSTALLER_BINARY_NAME}.tar.gz"
-    CONTRIBUTOOR_URL="https://github.com/ethpandaops/contributoor-test/releases/download/v${VERSION}/contributoor-test_${VERSION}_${PLATFORM}_${ARCH}.tar.gz"
+    INSTALLER_URL="https://github.com/ethpandaops/contributoor-installer/releases/latest/download/${INSTALLER_BINARY_NAME}.tar.gz"
+    CONTRIBUTOOR_URL="https://github.com/ethpandaops/contributoor/releases/download/v${VERSION}/contributoor_${VERSION}_${PLATFORM}_${ARCH}.tar.gz"
 
     # Installation mode selection
     selected=1

--- a/internal/service/docker.go
+++ b/internal/service/docker.go
@@ -94,7 +94,7 @@ func (s *DockerService) IsRunning() (bool, error) {
 // Update pulls the latest image and restarts the container.
 func (s *DockerService) Update() error {
 	//nolint:gosec // validateComposePath() and filepath.Clean() in-use.
-	cmd := exec.Command("docker", "pull", fmt.Sprintf("ethpandaops/contributoor-test:%s", s.config.Version))
+	cmd := exec.Command("docker", "pull", fmt.Sprintf("ethpandaops/contributoor:%s", s.config.Version))
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to pull image: %w\nOutput: %s", err, string(output))
 	}


### PR DESCRIPTION
Move away from `-test` prefix now we're on the right track.

- Renamed repositories (github + [dockerhub](https://hub.docker.com/repository/docker/ethpandaops/contributoor))
- Update import paths
- Update `install.sh` references
- `go mod tidy`