### PR TITLE
feat(installer): use symlinks for better version handling of binaries

### DIFF
--- a/cmd/cli/commands/update/update.go
+++ b/cmd/cli/commands/update/update.go
@@ -89,7 +89,7 @@ func updateContributoor(
 		}
 	}()
 
-	// Determine target version first
+	// Determine target version first.
 	targetVersion, err = determineTargetVersion(c, github)
 	if err != nil || targetVersion == "" {
 		success = true
@@ -99,7 +99,7 @@ func updateContributoor(
 
 	fmt.Printf("%-20s: %s\n", "Latest Version", targetVersion)
 
-	// Check if update is needed
+	// Check if update is needed.
 	if targetVersion == currentVersion {
 		success = true
 
@@ -108,7 +108,7 @@ func updateContributoor(
 		return nil
 	}
 
-	// Update config version
+	// Update config version.
 	if configErr := updateConfigVersion(sidecarCfg, targetVersion); configErr != nil {
 		return configErr
 	}

--- a/cmd/cli/commands/update/update.go
+++ b/cmd/cli/commands/update/update.go
@@ -75,6 +75,7 @@ func updateContributoor(
 		targetVersion  string
 		cfg            = sidecarCfg.Get()
 		currentVersion = cfg.Version
+		err            error
 	)
 
 	fmt.Printf("%sUpdating Contributoor Version%s\n", tui.TerminalColorLightBlue, tui.TerminalColorReset)
@@ -82,16 +83,15 @@ func updateContributoor(
 
 	defer func() {
 		if !success {
-			if err := rollbackVersion(sidecarCfg, currentVersion); err != nil {
-				log.Error(err)
+			if rollbackErr := rollbackVersion(sidecarCfg, currentVersion); rollbackErr != nil {
+				log.Error(rollbackErr)
 			}
 		}
 	}()
 
-	// Determine target version.
-	targetVersion, err := determineTargetVersion(c, github)
+	// Determine target version first
+	targetVersion, err = determineTargetVersion(c, github)
 	if err != nil || targetVersion == "" {
-		// Flag as success, there's nothing to update on rollback if we fail to determine the target version.
 		success = true
 
 		return err
@@ -99,9 +99,8 @@ func updateContributoor(
 
 	fmt.Printf("%-20s: %s\n", "Latest Version", targetVersion)
 
-	// Check if update is needed.
+	// Check if update is needed
 	if targetVersion == currentVersion {
-		// Flag as success, there's nothing to update.
 		success = true
 
 		printUpdateStatus(c.IsSet("version"), targetVersion)
@@ -109,9 +108,9 @@ func updateContributoor(
 		return nil
 	}
 
-	// Update config version.
-	if uerr := updateConfigVersion(sidecarCfg, targetVersion); uerr != nil {
-		return uerr
+	// Update config version
+	if configErr := updateConfigVersion(sidecarCfg, targetVersion); configErr != nil {
+		return configErr
 	}
 
 	// Refresh our config state, given it was updated above.

--- a/internal/installer/config.go
+++ b/internal/installer/config.go
@@ -12,16 +12,19 @@ type Config struct {
 	DockerTag string
 	// GithubOrg is the organization name housing the sidecar repository.
 	GithubOrg string
-	// GithubRepo is the repository name of the sidecar repository.
-	GithubRepo string
+	// GithubContributoorRepo is the repository name of the sidecar repository.
+	GithubContributoorRepo string
+	// GithubInstallerRepo is the repository name of the installer repository.
+	GithubInstallerRepo string
 }
 
 // NewConfig returns the default installer configuration.
 func NewConfig() *Config {
 	return &Config{
-		LogLevel:    logrus.InfoLevel.String(),
-		DockerImage: "ethpandaops/contributoor",
-		GithubOrg:   "ethpandaops",
-		GithubRepo:  "contributoor",
+		LogLevel:               logrus.InfoLevel.String(),
+		DockerImage:            "ethpandaops/contributoor",
+		GithubOrg:              "ethpandaops",
+		GithubContributoorRepo: "contributoor",
+		GithubInstallerRepo:    "contributoor-installer",
 	}
 }

--- a/internal/service/github.go
+++ b/internal/service/github.go
@@ -66,7 +66,7 @@ type githubService struct {
 
 // NewGitHubService creates a new GitHubService.
 func NewGitHubService(log *logrus.Logger, installerCfg *installer.Config) (GitHubService, error) {
-	githubURL, err := validateGitHubURL(installerCfg.GithubOrg, installerCfg.GithubRepo)
+	githubURL, err := validateGitHubURL(installerCfg.GithubOrg, installerCfg.GithubContributoorRepo)
 	if err != nil {
 		return nil, fmt.Errorf("invalid github url: %w", err)
 	}

--- a/internal/sidecar/installer.go
+++ b/internal/sidecar/installer.go
@@ -1,0 +1,73 @@
+package sidecar
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/ethpandaops/contributoor-installer/internal/installer"
+	"github.com/ethpandaops/contributoor-installer/internal/tui"
+	"github.com/ethpandaops/contributoor/pkg/config/v1"
+)
+
+// updateInstaller updates the installer binary to the specified version.
+func updateInstaller(cfg *config.Config, installerCfg *installer.Config) error {
+	releaseDir := filepath.Join(cfg.ContributoorDirectory, "releases", fmt.Sprintf("installer-%s", cfg.Version))
+	if err := os.MkdirAll(releaseDir, 0755); err != nil {
+		return fmt.Errorf("failed to create release directory: %w", err)
+	}
+
+	// Download new version.
+	downloadURL := fmt.Sprintf("https://github.com/%s/%s/releases/download/v%s/contributoor-installer_%s_%s_%s.tar.gz",
+		installerCfg.GithubOrg,
+		installerCfg.GithubInstallerRepo,
+		cfg.Version,
+		cfg.Version,
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+
+	//nolint:gosec // controlled url.
+	resp, err := http.Get(downloadURL)
+	if err != nil {
+		return fmt.Errorf("failed to download installer: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download installer: HTTP %d", resp.StatusCode)
+	}
+
+	// Extract directly to release directory.
+	cmd := exec.Command("tar", "--no-same-owner", "-xzf", "-", "-C", releaseDir)
+	cmd.Stdin = resp.Body
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to extract installer: %w", err)
+	}
+
+	// Update symlink.
+	binPath := filepath.Join(cfg.ContributoorDirectory, "bin")
+	newBinary := filepath.Join(releaseDir, "contributoor")
+	symlink := filepath.Join(binPath, "contributoor")
+
+	// Set permissions and create symlink.
+	if err := os.Chmod(newBinary, 0755); err != nil {
+		return fmt.Errorf("failed to set binary permissions: %w", err)
+	}
+
+	if err := os.Remove(symlink); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove old symlink: %w", err)
+	}
+
+	if err := os.Symlink(newBinary, symlink); err != nil {
+		return fmt.Errorf("failed to create symlink: %w", err)
+	}
+
+	fmt.Printf("%sInstaller updated successfully%s\n", tui.TerminalColorGreen, tui.TerminalColorReset)
+
+	return nil
+}

--- a/internal/sidecar/installer_test.go
+++ b/internal/sidecar/installer_test.go
@@ -1,0 +1,222 @@
+package sidecar
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ethpandaops/contributoor-installer/internal/installer"
+	"github.com/ethpandaops/contributoor/pkg/config/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateInstaller(t *testing.T) {
+	// Setup a mock tar.gz file.
+	mockTarGz := createMockTarGz(t, "contributoor", []byte("mock-installer-binary"))
+
+	tests := []struct {
+		name         string
+		cfg          *config.Config
+		installerCfg *installer.Config
+		serverFunc   func() *httptest.Server
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name: "successful update",
+			cfg: &config.Config{
+				ContributoorDirectory: "",
+				Version:               "0.0.1",
+			},
+			installerCfg: &installer.Config{
+				GithubOrg:           "ethpandaops",
+				GithubInstallerRepo: "contributoor-installer",
+			},
+			serverFunc: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if _, err := w.Write(mockTarGz); err != nil {
+						t.Fatalf("failed to write mock tar.gz: %v", err)
+					}
+				}))
+			},
+			wantErr: false,
+		},
+		{
+			name: "404 error",
+			cfg: &config.Config{
+				ContributoorDirectory: "",
+				Version:               "0.0.1",
+			},
+			installerCfg: &installer.Config{
+				GithubOrg:           "ethpandaops",
+				GithubInstallerRepo: "contributoor-installer",
+			},
+			serverFunc: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			wantErr:     true,
+			errContains: "HTTP 404",
+		},
+		{
+			name: "invalid directory",
+			cfg: &config.Config{
+				ContributoorDirectory: "/nonexistent/directory",
+				Version:               "0.0.1",
+			},
+			installerCfg: &installer.Config{
+				GithubOrg:           "ethpandaops",
+				GithubInstallerRepo: "contributoor-installer",
+			},
+			serverFunc: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if _, err := w.Write(mockTarGz); err != nil {
+						t.Fatalf("failed to write mock tar.gz: %v", err)
+					}
+				}))
+			},
+			wantErr:     true,
+			errContains: "failed to create release directory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new temporary directory for each test.
+			if tt.cfg.ContributoorDirectory != "/nonexistent/directory" {
+				tempDir, err := os.MkdirTemp("", "installer-test-*")
+				require.NoError(t, err)
+				defer os.RemoveAll(tempDir)
+
+				// Create bin directory.
+				require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "bin"), 0755))
+
+				// Use the temp directory as the Contributoor directory for the test.
+				tt.cfg.ContributoorDirectory = tempDir
+			}
+
+			// Start test server.
+			server := tt.serverFunc()
+			defer server.Close()
+
+			// Override the download URL to use our test server.
+			origURL := fmt.Sprintf(
+				"https://github.com/%s/%s/releases/download/v%s/contributoor-installer_%s_%s_%s.tar.gz",
+				tt.installerCfg.GithubOrg,
+				tt.installerCfg.GithubInstallerRepo,
+				tt.cfg.Version,
+				tt.cfg.Version,
+				runtime.GOOS,
+				runtime.GOARCH,
+			)
+
+			// Patch http.Get to redirect GitHub URLs to our test server.
+			oldClient := http.DefaultClient
+			http.DefaultClient = &http.Client{
+				Transport: &mockTransport{
+					origURL:    origURL,
+					mockURL:    server.URL,
+					origClient: oldClient.Transport,
+				},
+			}
+			defer func() { http.DefaultClient = oldClient }()
+
+			err := updateInstaller(tt.cfg, tt.installerCfg)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+
+				// Verify the binary was created and is executable.
+				binPath := filepath.Join(tt.cfg.ContributoorDirectory, "bin", "contributoor")
+				_, err := os.Stat(binPath)
+				assert.NoError(t, err)
+
+				// Verify it's a symlink.
+				fi, err := os.Lstat(binPath)
+				assert.NoError(t, err)
+				assert.True(t, fi.Mode()&os.ModeSymlink != 0)
+
+				// Verify the symlink points to the correct release.
+				target, err := os.Readlink(binPath)
+				assert.NoError(t, err)
+				assert.Contains(t, target, fmt.Sprintf("installer-%s", tt.cfg.Version))
+			}
+		})
+	}
+}
+
+// mockTransport redirects GitHub URLs to our test server.
+type mockTransport struct {
+	origURL    string
+	mockURL    string
+	origClient http.RoundTripper
+}
+
+func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.String() == t.origURL {
+		newReq := *req
+
+		var err error
+
+		newReq.URL, err = req.URL.Parse(t.mockURL)
+		if err != nil {
+			return nil, err
+		}
+
+		if t.origClient == nil {
+			t.origClient = http.DefaultTransport
+		}
+
+		return t.origClient.RoundTrip(&newReq)
+	}
+
+	if t.origClient == nil {
+		t.origClient = http.DefaultTransport
+	}
+
+	return t.origClient.RoundTrip(req)
+}
+
+// createMockTarGz creates a mock tar.gz file for testing.
+func createMockTarGz(t *testing.T, filename string, data []byte) []byte {
+	t.Helper()
+
+	var (
+		buf bytes.Buffer
+		gw  = gzip.NewWriter(&buf)
+		tw  = tar.NewWriter(gw)
+		hdr = &tar.Header{
+			Name: filename,
+			Mode: 0755,
+			Size: int64(len(data)),
+		}
+	)
+
+	err := tw.WriteHeader(hdr)
+	require.NoError(t, err)
+
+	_, err = tw.Write(data)
+	require.NoError(t, err)
+
+	err = tw.Close()
+	require.NoError(t, err)
+
+	err = gw.Close()
+	require.NoError(t, err)
+
+	return buf.Bytes()
+}


### PR DESCRIPTION
Manages binaries via symlinks for smoother atomic updates.

Uses symlinks to handle both the installer and contributoor binaries, eg:

- `bin/contributoor` -> `releases/installer-{version}/contributoor`
- `bin/sentry` -> `releases/contributoor-{version}/sentry`

![Screenshot 2025-01-14 at 10 36 48](https://github.com/user-attachments/assets/77b42db2-80fc-4258-a501-35f730935b41)
