### PR TITLE
feat(config): allows configuration of metrics address

### DIFF
--- a/cmd/cli/commands/config/config_network.go
+++ b/cmd/cli/commands/config/config_network.go
@@ -85,6 +85,7 @@ func (p *NetworkConfigPage) initPage() {
 		p.description.SetText(networkDescriptions[option])
 	})
 	form.AddInputField("Beacon Node Address", p.display.sidecarCfg.Get().BeaconNodeAddress, 0, nil, nil)
+	form.AddInputField("Metrics Address", p.display.sidecarCfg.Get().MetricsAddress, 0, nil, nil)
 
 	// Add a save button and ensure we validate the input.
 	saveButton := tview.NewButton(tui.ButtonSaveSettings)
@@ -171,11 +172,19 @@ func (p *NetworkConfigPage) initPage() {
 func validateAndUpdateNetwork(p *NetworkConfigPage) {
 	networkDropdown, _ := p.form.GetFormItem(0).(*tview.DropDown)
 	beaconInput, _ := p.form.GetFormItem(1).(*tview.InputField)
+	metricsInput, _ := p.form.GetFormItem(2).(*tview.InputField)
 
 	_, networkName := networkDropdown.GetCurrentOption()
 	beaconAddress := beaconInput.GetText()
+	metricsAddress := metricsInput.GetText()
 
 	if err := validate.ValidateBeaconNodeAddress(beaconAddress); err != nil {
+		p.openErrorModal(err)
+
+		return
+	}
+
+	if err := validate.ValidateMetricsAddress(metricsAddress); err != nil {
 		p.openErrorModal(err)
 
 		return
@@ -184,6 +193,7 @@ func validateAndUpdateNetwork(p *NetworkConfigPage) {
 	if err := p.display.sidecarCfg.Update(func(cfg *config.Config) {
 		cfg.NetworkName = config.NetworkName(config.NetworkName_value[networkName])
 		cfg.BeaconNodeAddress = beaconAddress
+		cfg.MetricsAddress = metricsAddress
 	}); err != nil {
 		p.openErrorModal(err)
 

--- a/internal/validate/metrics.go
+++ b/internal/validate/metrics.go
@@ -1,0 +1,36 @@
+package validate
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ValidateMetricsAddress validates the metrics address.
+func ValidateMetricsAddress(address string) error {
+	// Empty address is valid (disables metrics).
+	if address == "" {
+		return nil
+	}
+
+	// If it's just a port, prepend with colon.
+	if !strings.Contains(address, ":") {
+		address = ":" + address
+	}
+
+	// If it's just a port or host:port without scheme, prepend http://.
+	if !strings.HasPrefix(address, "http://") && !strings.HasPrefix(address, "https://") {
+		address = "http://" + address
+	}
+
+	u, err := url.Parse(address)
+	if err != nil {
+		return fmt.Errorf("invalid metrics address: %v", err)
+	}
+
+	if u.Port() == "" {
+		return fmt.Errorf("metrics address must include a port")
+	}
+
+	return nil
+}

--- a/internal/validate/metrics_test.go
+++ b/internal/validate/metrics_test.go
@@ -1,0 +1,66 @@
+package validate
+
+import "testing"
+
+func TestValidateMetricsAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{
+			name:    "empty address",
+			address: "",
+			wantErr: false,
+		},
+		{
+			name:    "just port",
+			address: "9090",
+			wantErr: false,
+		},
+		{
+			name:    "colon port",
+			address: ":9090",
+			wantErr: false,
+		},
+		{
+			name:    "localhost with port",
+			address: "localhost:9090",
+			wantErr: false,
+		},
+		{
+			name:    "ip with port",
+			address: "127.0.0.1:9090",
+			wantErr: false,
+		},
+		{
+			name:    "http url with port",
+			address: "http://127.0.0.1:9090",
+			wantErr: false,
+		},
+		{
+			name:    "https url with port",
+			address: "https://127.0.0.1:9090",
+			wantErr: false,
+		},
+		{
+			name:    "missing port",
+			address: "127.0.0.1",
+			wantErr: true,
+		},
+		{
+			name:    "http url without port",
+			address: "http://127.0.0.1",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMetricsAddress(tt.address)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateMetricsAddress() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the ability configure `metricsAddress` via `contributoor config`.

![Screenshot 2025-01-14 at 13 43 44](https://github.com/user-attachments/assets/71b90e9c-b5df-4e9f-bc4a-38666b7ab663)
