### PR TITLE
fix(update): return err if installer fails to update

### DIFF
--- a/internal/sidecar/binary.go
+++ b/internal/sidecar/binary.go
@@ -189,7 +189,7 @@ func (s *binarySidecar) Update() error {
 
 	// Update installer first
 	if err := updateInstaller(cfg, s.installerCfg); err != nil {
-		s.logger.Warnf("Failed to update installer: %v", err)
+		return fmt.Errorf("failed to update installer: %w", err)
 	}
 
 	// Update sidecar

--- a/internal/sidecar/docker.go
+++ b/internal/sidecar/docker.go
@@ -128,7 +128,7 @@ func (s *dockerSidecar) Update() error {
 
 	// Update installer first.
 	if err := updateInstaller(cfg, s.installerCfg); err != nil {
-		s.logger.Warnf("Failed to update installer: %v", err)
+		return fmt.Errorf("failed to update installer: %w", err)
 	}
 
 	// Update sidecar.


### PR DESCRIPTION
Ensure we error if installer fails to update, otherwise it'll fall-through, update contributoor and we're outta sync.