### PR TITLE
fix(docker): ensure orphaned contributoor containers can be managed

### DIFF
--- a/internal/sidecar/docker.go
+++ b/internal/sidecar/docker.go
@@ -83,7 +83,8 @@ func (s *dockerSidecar) Start() error {
 
 // Stop stops and removes the docker container using docker-compose.
 func (s *dockerSidecar) Stop() error {
-	// Stop and remove containers, volumes, and networks
+	// First try to stop via compose. If there has been any sort of configuration change
+	// between versions, then this will not stop the container.
 	//nolint:gosec // validateComposePath() and filepath.Clean() in-use.
 	cmd := exec.Command("docker", "compose", "-f", s.composePath, "down",
 		"--remove-orphans",
@@ -93,7 +94,15 @@ func (s *dockerSidecar) Stop() error {
 	cmd.Env = s.getComposeEnv()
 
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to stop containers: %w\nOutput: %s", err, string(output))
+		// Don't return error here, try our fallback.
+		s.logger.Warnf("failed to stop via compose: %v\noutput: %s", err, string(output))
+	}
+
+	// Fallback in the case of a configuration change between versions, attempt to remove
+	// the container by name.
+	cmd = exec.Command("docker", "rm", "-f", "contributoor")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to stop container: %w\nOutput: %s", err, string(output))
 	}
 
 	fmt.Printf("%sContributoor stopped successfully%s\n", tui.TerminalColorGreen, tui.TerminalColorReset)
@@ -103,23 +112,31 @@ func (s *dockerSidecar) Stop() error {
 
 // IsRunning checks if the docker container is running.
 func (s *dockerSidecar) IsRunning() (bool, error) {
+	// Check via compose first. If there has been any sort of configuration change between
+	// versions, then this will return a non running state.
 	//nolint:gosec // validateComposePath() and filepath.Clean() in-use.
 	cmd := exec.Command("docker", "compose", "-f", s.composePath, "ps", "--format", "{{.State}}")
 	cmd.Env = s.getComposeEnv()
 
 	output, err := cmd.Output()
+	if err == nil {
+		states := strings.Split(strings.TrimSpace(string(output)), "\n")
+		for _, state := range states {
+			if strings.Contains(strings.ToLower(state), "running") {
+				return true, nil
+			}
+		}
+	}
+
+	// In that case, we will fallback to checking for any container with the name 'contributoor'.
+	cmd = exec.Command("docker", "ps", "-q", "-f", "name=contributoor", "-f", "status=running")
+
+	output, err = cmd.Output()
 	if err != nil {
 		return false, fmt.Errorf("failed to check container status: %w", err)
 	}
 
-	states := strings.Split(strings.TrimSpace(string(output)), "\n")
-	for _, state := range states {
-		if strings.Contains(strings.ToLower(state), "running") {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return len(strings.TrimSpace(string(output))) > 0, nil
 }
 
 // Update pulls the latest image and restarts the container.

--- a/internal/sidecar/docker.go
+++ b/internal/sidecar/docker.go
@@ -95,7 +95,7 @@ func (s *dockerSidecar) Stop() error {
 
 	if output, err := cmd.CombinedOutput(); err != nil {
 		// Don't return error here, try our fallback.
-		s.logger.Warnf("failed to stop via compose: %v\noutput: %s", err, string(output))
+		s.logger.Debugf("failed to stop via compose: %v\noutput: %s", err, string(output))
 	}
 
 	// Fallback in the case of a configuration change between versions, attempt to remove

--- a/internal/sidecar/docker_test.go
+++ b/internal/sidecar/docker_test.go
@@ -3,11 +3,9 @@ package sidecar_test
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -126,18 +124,10 @@ func TestDockerService_Integration(t *testing.T) {
 		for {
 			select {
 			case <-ctx.Done():
-				// Fix data race by using a mutex for logs access
-				var logsMutex sync.Mutex
-				logsMutex.Lock()
 				logs, err := container.Logs(context.Background())
 				if err == nil {
-					// Convert logs to string before logging
-					logsBytes, err := io.ReadAll(logs)
-					if err == nil {
-						t.Logf("docker-in-docker container logs:\n%s", string(logsBytes))
-					}
+					t.Logf("docker-in-docker container logs:\n%s", logs)
 				}
-				logsMutex.Unlock()
 				t.Fatal("timeout waiting for docker-in-docker container to become healthy")
 			default:
 				running, err := ds.IsRunning()


### PR DESCRIPTION
**Problem:**

```
Restarting Contributoor
Contributoor is not running, starting contributoor
ERRO[0002] failed to start service: failed to start containers: exit status 1
Output:  sentry Pulling
 sentry Pulled
 Network installer-0035_contributoor  Creating
 Network installer-0035_contributoor  Created
 Container contributoor  Creating
Error response from daemon: Conflict. The container name "/contributoor" is already in use by container "5bd18e54e72b1b9c38678b14dd6688fb67f2df15f705417e0b5f0b9c84b163ca". You have to remove (or rename) that container to be able to reuse that name.`
```

Our `IsRunning()` implementation only checks for active containers with the exact configuration it expects, if this has changed (say between versions), then `IsRunning()` will return false.

Likewise with `Stop()`. It'll only attempt to stop containers started with the exact configuration it was started with, if this has changed, then it won't stop the container.

`IsRunning()` + `Stop()` have been updated to fallback to checking via container name, not just relying on `docker compose` which expects consistent config.