### PR TITLE
chore: Update installer version variable names

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -3,7 +3,7 @@ name: go-test
 on:
   push:
     branches:
-      - '**'
+      - master
   pull_request:
 
 permissions:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -3,7 +3,7 @@ name: golangci-lint
 on:
   push:
     branches:
-      - '**'
+      - master
   pull_request:
 
 permissions:

--- a/.github/workflows/shell-test.yml
+++ b/.github/workflows/shell-test.yml
@@ -2,7 +2,8 @@ name: shell-test
 
 on:
   push:
-    branches: [ 'master' ]
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/install.bats
+++ b/install.bats
@@ -341,15 +341,14 @@ EOF
 
 @test "setup_installer downloads and verifies checksums" {
     # Create required directories
-    mkdir -p "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}"
+    mkdir -p "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}"
     mkdir -p "$CONTRIBUTOOR_PATH/bin"
     
     # Set required variables
     ARCH="amd64"
     PLATFORM="linux"
-    INSTALLER_VERSION="1.0.0"
-    INSTALLER_BINARY_NAME="contributoor-installer_${INSTALLER_VERSION}_${PLATFORM}_${ARCH}"
-    INSTALLER_URL="https://github.com/ethpandaops/contributoor-installer/releases/download/v${INSTALLER_VERSION}/${INSTALLER_BINARY_NAME}.tar.gz"
+    INSTALLER_BINARY_NAME="contributoor-installer_${CONTRIBUTOOR_VERSION}_${PLATFORM}_${ARCH}"
+    INSTALLER_URL="https://github.com/ethpandaops/contributoor-installer/releases/download/v${CONTRIBUTOOR_VERSION}/${INSTALLER_BINARY_NAME}.tar.gz"
     
     # Mock the curl commands
     function curl() {
@@ -392,13 +391,13 @@ EOF
     # Mock tar extraction
     function tar() {
         # Create the binary and make it executable
-        touch "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/contributoor"
-        chmod +x "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/contributoor"
+        touch "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/contributoor"
+        chmod +x "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/contributoor"
         
         # Create compose files
-        touch "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/docker-compose.yml"
-        touch "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/docker-compose.ports.yml"
-        touch "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/docker-compose.network.yml"
+        touch "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/docker-compose.yml"
+        touch "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/docker-compose.ports.yml"
+        touch "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/docker-compose.network.yml"
         
         return 0
     }
@@ -412,9 +411,9 @@ EOF
             
             # Also create compose files in the same directory if it's the binary symlink
             if [[ "$3" == *"/bin/contributoor" ]]; then
-                cp "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/docker-compose.yml" "$(dirname "$3")/docker-compose.yml"
-                cp "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/docker-compose.ports.yml" "$(dirname "$3")/docker-compose.ports.yml"
-                cp "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/docker-compose.network.yml" "$(dirname "$3")/docker-compose.network.yml"
+                cp "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/docker-compose.yml" "$(dirname "$3")/docker-compose.yml"
+                cp "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/docker-compose.ports.yml" "$(dirname "$3")/docker-compose.ports.yml"
+                cp "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/docker-compose.network.yml" "$(dirname "$3")/docker-compose.network.yml"
             fi
         fi
         return 0
@@ -428,13 +427,13 @@ EOF
     echo "Output: $output"
     
     [ "$status" -eq 0 ]
-    [ -f "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/contributoor" ]
-    [ -x "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/contributoor" ]
+    [ -f "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/contributoor" ]
+    [ -x "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/contributoor" ]
     [ -f "$CONTRIBUTOOR_PATH/bin/contributoor" ]
     [ -x "$CONTRIBUTOOR_PATH/bin/contributoor" ]
-    [ -f "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/docker-compose.yml" ]
-    [ -f "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/docker-compose.ports.yml" ]
-    [ -f "$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}/docker-compose.network.yml" ]
+    [ -f "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/docker-compose.yml" ]
+    [ -f "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/docker-compose.ports.yml" ]
+    [ -f "$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}/docker-compose.network.yml" ]
 }
 
 @test "setup_installer fails on checksum mismatch" {
@@ -443,9 +442,9 @@ EOF
     # Set required variables
     ARCH="amd64"
     PLATFORM="linux"
-    INSTALLER_VERSION="1.0.0"
-    INSTALLER_BINARY_NAME="contributoor-installer_${INSTALLER_VERSION}_${PLATFORM}_${ARCH}"
-    INSTALLER_URL="https://github.com/ethpandaops/contributoor-installer/releases/download/v${INSTALLER_VERSION}/${INSTALLER_BINARY_NAME}.tar.gz"
+    CONTRIBUTOOR_VERSION="1.0.0"
+    INSTALLER_BINARY_NAME="contributoor-installer_${CONTRIBUTOOR_VERSION}_${PLATFORM}_${ARCH}"
+    INSTALLER_URL="https://github.com/ethpandaops/contributoor-installer/releases/download/v${CONTRIBUTOOR_VERSION}/${INSTALLER_BINARY_NAME}.tar.gz"
     
     # Mock curl to return different checksums
     function curl() {

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,6 @@ TOTAL_STEPS="9"
 CONTRIBUTOOR_PATH=${CONTRIBUTOOR_PATH:-"$HOME/.contributoor"}
 CONTRIBUTOOR_BIN="$CONTRIBUTOOR_PATH/bin"
 CONTRIBUTOOR_VERSION="latest"
-INSTALLER_VERSION="latest"
 ADDED_TO_PATH=false
 
 ###############################################################################
@@ -159,9 +158,9 @@ add_to_path() {
 
 setup_installer() {
     local temp_archive=$(mktemp)
-    local checksums_url="https://github.com/ethpandaops/contributoor-installer/releases/download/v${INSTALLER_VERSION}/contributoor-installer_${INSTALLER_VERSION}_checksums.txt"
+    local checksums_url="https://github.com/ethpandaops/contributoor-installer/releases/download/v${CONTRIBUTOOR_VERSION}/contributoor-installer_${CONTRIBUTOOR_VERSION}_checksums.txt"
     local checksums_file=$(mktemp)
-    local release_dir="$CONTRIBUTOOR_PATH/releases/installer-${INSTALLER_VERSION}"
+    local release_dir="$CONTRIBUTOOR_PATH/releases/installer-${CONTRIBUTOOR_VERSION}"
     
     # Create version-specific release directory
     mkdir -p "$release_dir"
@@ -623,8 +622,6 @@ main() {
 
     # Version management
     progress 2 "Determining version"
-    INSTALLER_VERSION=$(get_latest_installer_version)
-
     if [ "$CONTRIBUTOOR_VERSION" = "latest" ]; then
         CONTRIBUTOOR_VERSION=$(get_latest_contributoor_version)
         success "Latest contributoor version: $CONTRIBUTOOR_VERSION"
@@ -651,8 +648,8 @@ main() {
     success "logs directory: $CONTRIBUTOOR_PATH/logs"
 
     # Setup URLs
-    INSTALLER_BINARY_NAME="contributoor-installer_${INSTALLER_VERSION}_${PLATFORM}_${ARCH}"
-    INSTALLER_URL="https://github.com/ethpandaops/contributoor-installer/releases/download/v${INSTALLER_VERSION}/${INSTALLER_BINARY_NAME}.tar.gz"
+    INSTALLER_BINARY_NAME="contributoor-installer_${CONTRIBUTOOR_VERSION}_${PLATFORM}_${ARCH}"
+    INSTALLER_URL="https://github.com/ethpandaops/contributoor-installer/releases/download/v${CONTRIBUTOOR_VERSION}/${INSTALLER_BINARY_NAME}.tar.gz"
     CONTRIBUTOOR_URL="https://github.com/ethpandaops/contributoor/releases/download/v${CONTRIBUTOOR_VERSION}/contributoor_${CONTRIBUTOOR_VERSION}_${PLATFORM}_${ARCH}.tar.gz"
 
     # Installation mode selection


### PR DESCRIPTION
- lockstep versioning is in-place between `contributoor` and `contributoor-installer`. simplify `install.sh` by using single ver var.
- save some trees in ci builds