### PR TITLE
refactor: add binary checks and version mismatch logic

### DIFF
--- a/internal/sidecar/installer.go
+++ b/internal/sidecar/installer.go
@@ -71,3 +71,15 @@ func updateInstaller(cfg *config.Config, installerCfg *installer.Config) error {
 
 	return nil
 }
+
+// wrapNotInstalledError wraps an error with a user-friendly message.
+func wrapNotInstalledError(err error, mode string) error {
+	return fmt.Errorf("error:\n\n"+
+		"Contributoor is not installed under %s mode. Please run 'contributoor install' first, selecting the %s mode as your preferred run mode.\n\n"+
+		"This can occur if you switch between run modes and haven't completed installation for the new mode.\n\n"+
+		"Debug details: %w",
+		mode,
+		mode,
+		err,
+	)
+}


### PR DESCRIPTION
Its possible users can get themselves into a situation where their config defined version does not match that of the binary being run, by switching between `runMethod`'s.

**Scenario:**
- User installs via `binary`, v0.0.30
- User switches to `docker`
- User updates to v0.0.35
- User switches back to `binary`, at which time, it's sym-linked to the older v0.0.30.

**This PR:**
- Runs version mismatch checks on `contributoor start`, if a mismatch is detected, updates them to whats defined in their config.
- Additional checks prompting users to re-run `install.sh` if they switch modes without first having installed that method.

![Screenshot 2025-01-17 at 13 58 13](https://github.com/user-attachments/assets/520056e3-43de-4562-b1a4-1d3ee41546a5)

![Screenshot 2025-01-17 at 14 15 08](https://github.com/user-attachments/assets/1ff4dd2b-a95e-41b1-add7-e3b964778e9c)

