### PR TITLE
refactor(version): handle 'latest' version checks is a more robust way

### DIFF
--- a/cmd/cli/commands/restart/restart.go
+++ b/cmd/cli/commands/restart/restart.go
@@ -68,13 +68,6 @@ func restartContributoor(
 		cfg    = sidecarCfg.Get()
 	)
 
-	latestVersion, err := github.GetLatestVersion()
-	if err == nil && cfg.Version != latestVersion {
-		tui.UpgradeWarning(latestVersion)
-	}
-
-	fmt.Printf("%sRestarting Contributoor%s\n", tui.TerminalColorLightBlue, tui.TerminalColorReset)
-
 	// Determine which runner to use
 	switch cfg.RunMethod {
 	case config.RunMethod_RUN_METHOD_DOCKER:
@@ -86,6 +79,14 @@ func restartContributoor(
 	default:
 		return fmt.Errorf("invalid sidecar run method: %s", cfg.RunMethod)
 	}
+
+	// Check version and show upgrade warning if needed.
+	current, latest, needsUpdate, err := sidecar.CheckVersion(runner, github, cfg.Version)
+	if err == nil && needsUpdate {
+		tui.UpgradeWarning(current, latest)
+	}
+
+	fmt.Printf("%sRestarting Contributoor%s\n", tui.TerminalColorLightBlue, tui.TerminalColorReset)
 
 	// Check if running
 	running, err := runner.IsRunning()

--- a/cmd/cli/commands/restart/restart_test.go
+++ b/cmd/cli/commands/restart/restart_test.go
@@ -6,6 +6,7 @@ import (
 
 	servicemock "github.com/ethpandaops/contributoor-installer/internal/service/mock"
 	"github.com/ethpandaops/contributoor-installer/internal/sidecar/mock"
+	"github.com/ethpandaops/contributoor-installer/internal/test"
 	"github.com/ethpandaops/contributoor/pkg/config/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,9 @@ import (
 
 func TestRestartContributoor(t *testing.T) {
 	t.Run("restarts running docker sidecar", func(t *testing.T) {
+		cleanup := test.SuppressOutput(t)
+		defer cleanup()
+
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -22,10 +26,12 @@ func TestRestartContributoor(t *testing.T) {
 		mockConfig := mock.NewMockConfigManager(ctrl)
 		mockConfig.EXPECT().Get().Return(&config.Config{
 			RunMethod: config.RunMethod_RUN_METHOD_DOCKER,
+			Version:   "latest",
 		}).AnyTimes()
 
 		// Create mock docker sidecar that's running
 		mockDocker := mock.NewMockDockerSidecar(ctrl)
+		mockDocker.EXPECT().Version().Return("1.0.0", nil)
 		mockDocker.EXPECT().IsRunning().Return(true, nil)
 		mockDocker.EXPECT().Stop().Return(nil)
 		mockDocker.EXPECT().Start().Return(nil)
@@ -48,6 +54,9 @@ func TestRestartContributoor(t *testing.T) {
 	})
 
 	t.Run("starts stopped systemd sidecar", func(t *testing.T) {
+		cleanup := test.SuppressOutput(t)
+		defer cleanup()
+
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -55,10 +64,12 @@ func TestRestartContributoor(t *testing.T) {
 		mockConfig := mock.NewMockConfigManager(ctrl)
 		mockConfig.EXPECT().Get().Return(&config.Config{
 			RunMethod: config.RunMethod_RUN_METHOD_SYSTEMD,
+			Version:   "latest",
 		}).AnyTimes()
 
 		// Create mock systemd sidecar that's not running
 		mockSystemd := mock.NewMockSystemdSidecar(ctrl)
+		mockSystemd.EXPECT().Version().Return("1.0.0", nil)
 		mockSystemd.EXPECT().IsRunning().Return(false, nil)
 		mockSystemd.EXPECT().Start().Return(nil)
 
@@ -80,16 +91,21 @@ func TestRestartContributoor(t *testing.T) {
 	})
 
 	t.Run("handles stop error", func(t *testing.T) {
+		cleanup := test.SuppressOutput(t)
+		defer cleanup()
+
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockConfig := mock.NewMockConfigManager(ctrl)
 		mockConfig.EXPECT().Get().Return(&config.Config{
 			RunMethod: config.RunMethod_RUN_METHOD_BINARY,
+			Version:   "latest",
 		}).AnyTimes()
 
 		// Create mock binary sidecar that fails to stop
 		mockBinary := mock.NewMockBinarySidecar(ctrl)
+		mockBinary.EXPECT().Version().Return("1.0.0", nil)
 		mockBinary.EXPECT().IsRunning().Return(true, nil)
 		mockBinary.EXPECT().Stop().Return(errors.New("test error"))
 
@@ -112,16 +128,21 @@ func TestRestartContributoor(t *testing.T) {
 	})
 
 	t.Run("handles start error", func(t *testing.T) {
+		cleanup := test.SuppressOutput(t)
+		defer cleanup()
+
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockConfig := mock.NewMockConfigManager(ctrl)
 		mockConfig.EXPECT().Get().Return(&config.Config{
 			RunMethod: config.RunMethod_RUN_METHOD_BINARY,
+			Version:   "latest",
 		}).AnyTimes()
 
 		// Create mock binary sidecar that fails to start
 		mockBinary := mock.NewMockBinarySidecar(ctrl)
+		mockBinary.EXPECT().Version().Return("1.0.0", nil)
 		mockBinary.EXPECT().IsRunning().Return(false, nil)
 		mockBinary.EXPECT().Start().Return(errors.New("test error"))
 
@@ -144,17 +165,17 @@ func TestRestartContributoor(t *testing.T) {
 	})
 
 	t.Run("handles invalid run method", func(t *testing.T) {
+		cleanup := test.SuppressOutput(t)
+		defer cleanup()
+
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockConfig := mock.NewMockConfigManager(ctrl)
 		mockConfig.EXPECT().Get().Return(&config.Config{
 			RunMethod: config.RunMethod_RUN_METHOD_UNSPECIFIED,
+			Version:   "latest",
 		}).AnyTimes()
-
-		// Create mock GitHub service
-		mockGitHub := servicemock.NewMockGitHubService(ctrl)
-		mockGitHub.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
 
 		err := restartContributoor(
 			cli.NewContext(nil, nil, nil),
@@ -163,7 +184,7 @@ func TestRestartContributoor(t *testing.T) {
 			mock.NewMockDockerSidecar(ctrl),
 			mock.NewMockSystemdSidecar(ctrl),
 			mock.NewMockBinarySidecar(ctrl),
-			mockGitHub,
+			servicemock.NewMockGitHubService(ctrl),
 		)
 
 		assert.Error(t, err)
@@ -171,12 +192,16 @@ func TestRestartContributoor(t *testing.T) {
 	})
 
 	t.Run("handles github error gracefully", func(t *testing.T) {
+		cleanup := test.SuppressOutput(t)
+		defer cleanup()
+
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockConfig := mock.NewMockConfigManager(ctrl)
 		mockConfig.EXPECT().Get().Return(&config.Config{
 			RunMethod: config.RunMethod_RUN_METHOD_DOCKER,
+			Version:   "latest",
 		}).AnyTimes()
 
 		mockDocker := mock.NewMockDockerSidecar(ctrl)

--- a/cmd/cli/commands/start/start.go
+++ b/cmd/cli/commands/start/start.go
@@ -68,13 +68,6 @@ func startContributoor(
 		cfg    = sidecarCfg.Get()
 	)
 
-	latestVersion, err := github.GetLatestVersion()
-	if err == nil && cfg.Version != latestVersion {
-		tui.UpgradeWarning(latestVersion)
-	}
-
-	fmt.Printf("%sStarting Contributoor%s\n", tui.TerminalColorLightBlue, tui.TerminalColorReset)
-
 	// Start the sidecar via whatever method the user has configured (docker or binary).
 	switch cfg.RunMethod {
 	case config.RunMethod_RUN_METHOD_DOCKER:
@@ -86,6 +79,14 @@ func startContributoor(
 	default:
 		return fmt.Errorf("invalid sidecar run method: %s", cfg.RunMethod)
 	}
+
+	// Check version and show upgrade warning if needed.
+	current, latest, needsUpdate, err := sidecar.CheckVersion(runner, github, cfg.Version)
+	if err == nil && needsUpdate {
+		tui.UpgradeWarning(current, latest)
+	}
+
+	fmt.Printf("%sStarting Contributoor%s\n", tui.TerminalColorLightBlue, tui.TerminalColorReset)
 
 	// Check if the sidecar is already running.
 	running, err := runner.IsRunning()

--- a/cmd/cli/commands/start/start_test.go
+++ b/cmd/cli/commands/start/start_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethpandaops/contributoor-installer/cmd/cli/options"
 	servicemock "github.com/ethpandaops/contributoor-installer/internal/service/mock"
 	sidecarmock "github.com/ethpandaops/contributoor-installer/internal/sidecar/mock"
+	"github.com/ethpandaops/contributoor-installer/internal/test"
 	"github.com/ethpandaops/contributoor/pkg/config/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,7 @@ func TestStartContributoor(t *testing.T) {
 					Version:   "latest",
 				}).Times(1)
 				gh.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
+				d.EXPECT().Version().Return("1.0.0", nil)
 				d.EXPECT().IsRunning().Return(false, nil)
 				d.EXPECT().Start().Return(nil)
 			},
@@ -48,6 +50,7 @@ func TestStartContributoor(t *testing.T) {
 					Version:   "latest",
 				}).Times(1)
 				gh.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
+				d.EXPECT().Version().Return("1.0.0", nil)
 				d.EXPECT().IsRunning().Return(true, nil)
 			},
 		},
@@ -60,6 +63,7 @@ func TestStartContributoor(t *testing.T) {
 					Version:   "latest",
 				}).Times(1)
 				gh.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
+				d.EXPECT().Version().Return("1.0.0", nil)
 				d.EXPECT().IsRunning().Return(false, nil)
 				d.EXPECT().Start().Return(errors.New("start failed"))
 			},
@@ -74,6 +78,7 @@ func TestStartContributoor(t *testing.T) {
 					Version:   "latest",
 				}).Times(1)
 				gh.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
+				b.EXPECT().Version().Return("1.0.0", nil)
 				b.EXPECT().IsRunning().Return(false, nil)
 				b.EXPECT().Start().Return(nil)
 			},
@@ -87,6 +92,7 @@ func TestStartContributoor(t *testing.T) {
 					Version:   "latest",
 				}).Times(1)
 				gh.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
+				b.EXPECT().Version().Return("1.0.0", nil)
 				b.EXPECT().IsRunning().Return(true, nil)
 			},
 		},
@@ -98,7 +104,6 @@ func TestStartContributoor(t *testing.T) {
 					RunMethod: config.RunMethod_RUN_METHOD_UNSPECIFIED,
 					Version:   "latest",
 				}).Times(1)
-				gh.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
 			},
 			expectedError: "invalid sidecar run method",
 		},
@@ -106,6 +111,9 @@ func TestStartContributoor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			cleanup := test.SuppressOutput(t)
+			defer cleanup()
+
 			mockConfig := sidecarmock.NewMockConfigManager(ctrl)
 			mockDocker := sidecarmock.NewMockDockerSidecar(ctrl)
 			mockBinary := sidecarmock.NewMockBinarySidecar(ctrl)
@@ -131,6 +139,9 @@ func TestStartContributoor(t *testing.T) {
 }
 
 func TestRegisterCommands(t *testing.T) {
+	cleanup := test.SuppressOutput(t)
+	defer cleanup()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/cmd/cli/commands/status/status.go
+++ b/cmd/cli/commands/status/status.go
@@ -70,11 +70,6 @@ func showStatus(
 		cfg    = sidecarCfg.Get()
 	)
 
-	latestVersion, err := github.GetLatestVersion()
-	if err == nil && cfg.Version != latestVersion {
-		tui.UpgradeWarning(latestVersion)
-	}
-
 	// Determine which runner to use.
 	switch cfg.RunMethod {
 	case config.RunMethod_RUN_METHOD_DOCKER:
@@ -85,6 +80,12 @@ func showStatus(
 		runner = binary
 	default:
 		return fmt.Errorf("invalid sidecar run method: %s", cfg.RunMethod)
+	}
+
+	// Check version and show upgrade warning if needed.
+	current, latest, needsUpdate, err := sidecar.CheckVersion(runner, github, cfg.Version)
+	if err == nil && needsUpdate {
+		tui.UpgradeWarning(current, latest)
 	}
 
 	// Check if running.
@@ -101,7 +102,7 @@ func showStatus(
 
 	// Print status information.
 	fmt.Printf("%sContributoor Status%s\n", tui.TerminalColorLightBlue, tui.TerminalColorReset)
-	fmt.Printf("%-20s: %s\n", "Version", cfg.Version)
+	fmt.Printf("%-20s: %s\n", "Version", current)
 	fmt.Printf("%-20s: %s\n", "Run Method", cfg.RunMethod)
 	fmt.Printf("%-20s: %s\n", "Network", cfg.NetworkName)
 	fmt.Printf("%-20s: %s\n", "Beacon Node", cfg.BeaconNodeAddress)

--- a/cmd/cli/commands/status/status_test.go
+++ b/cmd/cli/commands/status/status_test.go
@@ -124,6 +124,7 @@ func TestShowStatus(t *testing.T) {
 
 			if tt.expectedError != "" {
 				assert.ErrorContains(t, err, tt.expectedError)
+
 				return
 			}
 

--- a/cmd/cli/commands/stop/stop.go
+++ b/cmd/cli/commands/stop/stop.go
@@ -68,13 +68,6 @@ func stopContributoor(
 		cfg    = sidecarCfg.Get()
 	)
 
-	latestVersion, err := github.GetLatestVersion()
-	if err == nil && cfg.Version != latestVersion {
-		tui.UpgradeWarning(latestVersion)
-	}
-
-	fmt.Printf("%sStopping Contributoor%s\n", tui.TerminalColorLightBlue, tui.TerminalColorReset)
-
 	// Stop the sidecar via whatever method the user has configured (docker or binary).
 	switch cfg.RunMethod {
 	case config.RunMethod_RUN_METHOD_DOCKER:
@@ -86,6 +79,14 @@ func stopContributoor(
 	default:
 		return fmt.Errorf("invalid sidecar run method: %s", cfg.RunMethod)
 	}
+
+	// Check version and show upgrade warning if needed.
+	current, latest, needsUpdate, err := sidecar.CheckVersion(runner, github, cfg.Version)
+	if err == nil && needsUpdate {
+		tui.UpgradeWarning(current, latest)
+	}
+
+	fmt.Printf("%sStopping Contributoor%s\n", tui.TerminalColorLightBlue, tui.TerminalColorReset)
 
 	if err := runner.Stop(); err != nil {
 		return err

--- a/cmd/cli/commands/stop/stop_test.go
+++ b/cmd/cli/commands/stop/stop_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethpandaops/contributoor-installer/cmd/cli/options"
 	servicemock "github.com/ethpandaops/contributoor-installer/internal/service/mock"
 	"github.com/ethpandaops/contributoor-installer/internal/sidecar/mock"
+	"github.com/ethpandaops/contributoor-installer/internal/test"
 	"github.com/ethpandaops/contributoor/pkg/config/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -34,8 +35,9 @@ func TestStopContributoor(t *testing.T) {
 					RunMethod: config.RunMethod_RUN_METHOD_DOCKER,
 					Version:   "latest",
 				}).Times(1)
-				d.EXPECT().Stop().Return(nil)
 				g.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
+				d.EXPECT().Version().Return("1.0.0", nil)
+				d.EXPECT().Stop().Return(nil)
 			},
 		},
 		{
@@ -44,9 +46,11 @@ func TestStopContributoor(t *testing.T) {
 			setupMocks: func(cfg *mock.MockConfigManager, d *mock.MockDockerSidecar, b *mock.MockBinarySidecar, g *servicemock.MockGitHubService) {
 				cfg.EXPECT().Get().Return(&config.Config{
 					RunMethod: config.RunMethod_RUN_METHOD_DOCKER,
+					Version:   "latest",
 				}).Times(1)
-				d.EXPECT().Stop().Return(errors.New("stop failed"))
 				g.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
+				d.EXPECT().Version().Return("1.0.0", nil)
+				d.EXPECT().Stop().Return(errors.New("stop failed"))
 			},
 			expectedError: "stop failed",
 		},
@@ -56,9 +60,11 @@ func TestStopContributoor(t *testing.T) {
 			setupMocks: func(cfg *mock.MockConfigManager, d *mock.MockDockerSidecar, b *mock.MockBinarySidecar, g *servicemock.MockGitHubService) {
 				cfg.EXPECT().Get().Return(&config.Config{
 					RunMethod: config.RunMethod_RUN_METHOD_BINARY,
+					Version:   "latest",
 				}).Times(1)
-				b.EXPECT().Stop().Return(nil)
 				g.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
+				b.EXPECT().Version().Return("1.0.0", nil)
+				b.EXPECT().Stop().Return(nil)
 			},
 		},
 		{
@@ -67,8 +73,8 @@ func TestStopContributoor(t *testing.T) {
 			setupMocks: func(cfg *mock.MockConfigManager, d *mock.MockDockerSidecar, b *mock.MockBinarySidecar, g *servicemock.MockGitHubService) {
 				cfg.EXPECT().Get().Return(&config.Config{
 					RunMethod: config.RunMethod_RUN_METHOD_UNSPECIFIED,
+					Version:   "latest",
 				}).Times(1)
-				g.EXPECT().GetLatestVersion().Return("v1.0.0", nil)
 			},
 			expectedError: "invalid sidecar run method",
 		},
@@ -78,15 +84,19 @@ func TestStopContributoor(t *testing.T) {
 			setupMocks: func(cfg *mock.MockConfigManager, d *mock.MockDockerSidecar, b *mock.MockBinarySidecar, g *servicemock.MockGitHubService) {
 				cfg.EXPECT().Get().Return(&config.Config{
 					RunMethod: config.RunMethod_RUN_METHOD_DOCKER,
+					Version:   "latest",
 				}).Times(1)
-				d.EXPECT().Stop().Return(nil)
 				g.EXPECT().GetLatestVersion().Return("", errors.New("github error"))
+				d.EXPECT().Stop().Return(nil)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			cleanup := test.SuppressOutput(t)
+			defer cleanup()
+
 			mockConfig := mock.NewMockConfigManager(ctrl)
 			mockDocker := mock.NewMockDockerSidecar(ctrl)
 			mockBinary := mock.NewMockBinarySidecar(ctrl)
@@ -102,7 +112,6 @@ func TestStopContributoor(t *testing.T) {
 
 			if tt.expectedError != "" {
 				assert.ErrorContains(t, err, tt.expectedError)
-
 				return
 			}
 
@@ -133,6 +142,9 @@ func TestRegisterCommands(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			cleanup := test.SuppressOutput(t)
+			defer cleanup()
+
 			// Create CLI app, with the config flag.
 			app := cli.NewApp()
 			app.Flags = []cli.Flag{

--- a/cmd/cli/commands/stop/stop_test.go
+++ b/cmd/cli/commands/stop/stop_test.go
@@ -112,6 +112,7 @@ func TestStopContributoor(t *testing.T) {
 
 			if tt.expectedError != "" {
 				assert.ErrorContains(t, err, tt.expectedError)
+
 				return
 			}
 

--- a/internal/sidecar/binary.go
+++ b/internal/sidecar/binary.go
@@ -286,6 +286,11 @@ func (s *binarySidecar) Logs(tailLines int, follow bool) error {
 	return cmd.Run()
 }
 
+// Version returns the version of the currently running binary.
+func (s *binarySidecar) Version() (string, error) {
+	return s.getBinaryVersion()
+}
+
 // updateSidecar updates the sidecar binary to the specified version.
 func (s *binarySidecar) updateSidecar() error {
 	cfg := s.sidecarCfg.Get()

--- a/internal/sidecar/mock/binary.mock.go
+++ b/internal/sidecar/mock/binary.mock.go
@@ -124,3 +124,18 @@ func (mr *MockBinarySidecarMockRecorder) Update() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockBinarySidecar)(nil).Update))
 }
+
+// Version mocks base method.
+func (m *MockBinarySidecar) Version() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Version")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Version indicates an expected call of Version.
+func (mr *MockBinarySidecarMockRecorder) Version() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockBinarySidecar)(nil).Version))
+}

--- a/internal/sidecar/mock/docker.mock.go
+++ b/internal/sidecar/mock/docker.mock.go
@@ -138,3 +138,18 @@ func (mr *MockDockerSidecarMockRecorder) Update() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDockerSidecar)(nil).Update))
 }
+
+// Version mocks base method.
+func (m *MockDockerSidecar) Version() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Version")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Version indicates an expected call of Version.
+func (mr *MockDockerSidecarMockRecorder) Version() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockDockerSidecar)(nil).Version))
+}

--- a/internal/sidecar/mock/systemd.mock.go
+++ b/internal/sidecar/mock/systemd.mock.go
@@ -124,3 +124,18 @@ func (mr *MockSystemdSidecarMockRecorder) Update() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockSystemdSidecar)(nil).Update))
 }
+
+// Version mocks base method.
+func (m *MockSystemdSidecar) Version() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Version")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Version indicates an expected call of Version.
+func (mr *MockSystemdSidecarMockRecorder) Version() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockSystemdSidecar)(nil).Version))
+}

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -31,4 +31,7 @@ type SidecarRunner interface {
 
 	// Logs returns the logs from the service.
 	Logs(tailLines int, follow bool) error
+
+	// Version returns the current version the underlying sidecar is running.
+	Version() (string, error)
 }

--- a/internal/sidecar/systemd.go
+++ b/internal/sidecar/systemd.go
@@ -350,3 +350,14 @@ func (s *systemdSidecar) Status() (string, error) {
 
 	return strings.TrimSpace(string(output)), nil
 }
+
+// Version returns the version of the currently running service.
+func (s *systemdSidecar) Version() (string, error) {
+	// Create a binary sidecar to check version since systemd/launchd uses the binary
+	bs, err := NewBinarySidecar(s.logger, s.sidecarCfg, s.installerCfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to create binary sidecar: %w", err)
+	}
+
+	return bs.Version()
+}

--- a/internal/sidecar/version.go
+++ b/internal/sidecar/version.go
@@ -1,0 +1,43 @@
+package sidecar
+
+import (
+	"fmt"
+
+	"github.com/ethpandaops/contributoor-installer/internal/service"
+)
+
+// CheckVersion checks if the current running version needs an update.
+// - For "latest" tag, it compares the actual running version with latest available.
+// - For specific versions, it compares the config version with latest available.
+func CheckVersion(
+	runner SidecarRunner,
+	github service.GitHubService,
+	configVersion string,
+) (currentVersion, latestVersion string, needsUpdate bool, err error) {
+	latestVersion, err = github.GetLatestVersion()
+	if err != nil {
+		err = fmt.Errorf("failed to get latest version: %w", err)
+
+		return currentVersion, latestVersion, false, err
+	}
+
+	if configVersion == "latest" {
+		// For "latest" tag, compare the actual running version with latest available.
+		currentVersion, err = runner.Version()
+		if err != nil {
+			err = fmt.Errorf("failed to get running version: %w", err)
+
+			return currentVersion, latestVersion, false, err
+		}
+
+		needsUpdate = currentVersion != latestVersion
+
+		return currentVersion, latestVersion, needsUpdate, nil
+	}
+
+	// For specific versions, compare config version with latest
+	currentVersion = configVersion
+	needsUpdate = currentVersion != latestVersion
+
+	return currentVersion, latestVersion, needsUpdate, nil
+}

--- a/internal/sidecar/version_test.go
+++ b/internal/sidecar/version_test.go
@@ -1,0 +1,108 @@
+package sidecar
+
+import (
+	"errors"
+	"testing"
+
+	servicemock "github.com/ethpandaops/contributoor-installer/internal/service/mock"
+	"github.com/ethpandaops/contributoor-installer/internal/sidecar/mock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCheckVersion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name                string
+		configVersion       string
+		setupMocks          func(*mock.MockDockerSidecar, *servicemock.MockGitHubService)
+		expectedCurrent     string
+		expectedLatest      string
+		expectedNeedsUpdate bool
+		expectedError       string
+	}{
+		{
+			name:          "latest tag - up to date",
+			configVersion: "latest",
+			setupMocks: func(r *mock.MockDockerSidecar, g *servicemock.MockGitHubService) {
+				g.EXPECT().GetLatestVersion().Return("1.0.0", nil)
+				r.EXPECT().Version().Return("1.0.0", nil)
+			},
+			expectedCurrent:     "1.0.0",
+			expectedLatest:      "1.0.0",
+			expectedNeedsUpdate: false,
+		},
+		{
+			name:          "latest tag - needs update",
+			configVersion: "latest",
+			setupMocks: func(r *mock.MockDockerSidecar, g *servicemock.MockGitHubService) {
+				g.EXPECT().GetLatestVersion().Return("2.0.0", nil)
+				r.EXPECT().Version().Return("1.0.0", nil)
+			},
+			expectedCurrent:     "1.0.0",
+			expectedLatest:      "2.0.0",
+			expectedNeedsUpdate: true,
+		},
+		{
+			name:          "specific version - up to date",
+			configVersion: "1.0.0",
+			setupMocks: func(r *mock.MockDockerSidecar, g *servicemock.MockGitHubService) {
+				g.EXPECT().GetLatestVersion().Return("1.0.0", nil)
+			},
+			expectedCurrent:     "1.0.0",
+			expectedLatest:      "1.0.0",
+			expectedNeedsUpdate: false,
+		},
+		{
+			name:          "specific version - needs update",
+			configVersion: "1.0.0",
+			setupMocks: func(r *mock.MockDockerSidecar, g *servicemock.MockGitHubService) {
+				g.EXPECT().GetLatestVersion().Return("2.0.0", nil)
+			},
+			expectedCurrent:     "1.0.0",
+			expectedLatest:      "2.0.0",
+			expectedNeedsUpdate: true,
+		},
+		{
+			name:          "github error",
+			configVersion: "latest",
+			setupMocks: func(r *mock.MockDockerSidecar, g *servicemock.MockGitHubService) {
+				g.EXPECT().GetLatestVersion().Return("", errors.New("github error"))
+			},
+			expectedError: "failed to get latest version",
+		},
+		{
+			name:          "version error with latest tag",
+			configVersion: "latest",
+			setupMocks: func(r *mock.MockDockerSidecar, g *servicemock.MockGitHubService) {
+				g.EXPECT().GetLatestVersion().Return("1.0.0", nil)
+				r.EXPECT().Version().Return("", errors.New("version error"))
+			},
+			expectedError: "failed to get running version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockGitHub := servicemock.NewMockGitHubService(ctrl)
+			mockRunner := mock.NewMockDockerSidecar(ctrl)
+
+			tt.setupMocks(mockRunner, mockGitHub)
+
+			current, latest, needsUpdate, err := CheckVersion(mockRunner, mockGitHub, tt.configVersion)
+
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError)
+
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedCurrent, current)
+			assert.Equal(t, tt.expectedLatest, latest)
+			assert.Equal(t, tt.expectedNeedsUpdate, needsUpdate)
+		})
+	}
+}

--- a/internal/test/output.go
+++ b/internal/test/output.go
@@ -1,0 +1,32 @@
+package test
+
+import (
+	"os"
+	"testing"
+)
+
+// SuppressOutput redirects stdout + stderr to /dev/null during test execution, otherwise its too noisy.
+func SuppressOutput(t *testing.T) func() {
+	t.Helper()
+
+	// Save original stdout and stderr.
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+
+	// Open /dev/null + redirect stdout + stderr.
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Stdout = devNull
+	os.Stderr = devNull
+
+	return func() {
+		devNull.Close()
+
+		// Restore original stdout and stderr.
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}
+}

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -50,7 +50,15 @@ func Prompt(initialPrompt string, expectedFormat string, incorrectFormatPrompt s
 }
 
 // UpgradeWarning prints a warning to the user that they are running an old version of contributoor.
-func UpgradeWarning(latestVersion string) {
+func UpgradeWarning(currentVersion string, latestVersion string) {
+	if currentVersion == "latest" {
+		return
+	}
+
+	if currentVersion == latestVersion {
+		return
+	}
+
 	fmt.Printf(
 		"%sYou are running an old version of contributoor; we suggest you to update it to the latest version, '%s%s%s'. You can manually upgrade by running 'contributoor update'.%s\n\n",
 		TerminalColorYellow,

--- a/internal/tui/shell_test.go
+++ b/internal/tui/shell_test.go
@@ -1,0 +1,69 @@
+package tui
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestUpgradeWarning(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		latestVersion  string
+		wantOutput     bool
+	}{
+		{
+			name:           "no warning when current is latest tag",
+			currentVersion: "latest",
+			latestVersion:  "v1.0.0",
+			wantOutput:     false,
+		},
+		{
+			name:           "no warning when versions match",
+			currentVersion: "v1.0.0",
+			latestVersion:  "v1.0.0",
+			wantOutput:     false,
+		},
+		{
+			name:           "warning when versions differ",
+			currentVersion: "v1.0.0",
+			latestVersion:  "v1.1.0",
+			wantOutput:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout.
+			old := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			UpgradeWarning(tt.currentVersion, tt.latestVersion)
+
+			// Restore stdout.
+			w.Close()
+			os.Stdout = old
+
+			var buf bytes.Buffer
+			_, _ = io.Copy(&buf, r)
+			output := buf.String()
+
+			if tt.wantOutput {
+				if !strings.Contains(output, "You are running an old version") {
+					t.Errorf("expected warning message, got none")
+				}
+				if !strings.Contains(output, tt.latestVersion) {
+					t.Errorf("expected version %s in output, not found", tt.latestVersion)
+				}
+			} else {
+				if output != "" {
+					t.Errorf("expected no output, got: %s", output)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When configuring contributoor, `version: latest` is a valid version. Contributoor will work out what the underlying `latest` version is.

The current implementation of checking versions and prompting the user is a naive (eg: `0.0.1 != 0.0.2`) expecting specific versions (not `latest`). This PR updates this logic to handle version checks more robustly.

- Inspect underlying binary for actual version being run, so when `latest` in use, we can compare.
- Refactors a few tests to make them consistent with others.
- Black-holes stdout/err in tests as it was getting way to noisy.