### PR TITLE
ci: Update golangci-lint action with timeout argument

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,3 +26,4 @@ jobs:
         uses: golangci/golangci-lint-action@v4
         with:
           version: latest
+          args: --timeout=10m


### PR DESCRIPTION
- Sporadically seeing a few lint timeouts, default is 1m. Pretty common practice to have to bump this, its a beast.