### PR TITLE
fix(install): ensure home dir expansion works as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ contributoor update   # Update to latest version
 contributoor logs     # Show logs
 ```
 
+If you chose to install contributoor under a custom directory, you will need to specify the directory when running the commands, for example:
+
+```bash
+contributoor --config-path /path/to/contributoor start
+```
+
 ## 🔨 Development
 
 <details>


### PR DESCRIPTION
See: https://github.com/ethpandaops/contributoor-installer/issues/87

When installing `contributoor`, users can specify a custom install directory. If the user specifies `~/path/to/x` we weren't expanding the `~` (home dir), leading to the install creating a directory of `~/path`.

This PR handles home expansion on install + uninstall.
