### PR TITLE
fix(installer): set xterm-256color

### DIFF
--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -1,0 +1,10 @@
+package tui
+
+import "os"
+
+func init() {
+	// Set to xterm-256color as it's widely supported and works well with tview.
+	// If whatever terminal we're using doesn't support it, it'll fallback to
+	// xterm normally anyway.
+	os.Setenv("TERM", "xterm-256color")
+}


### PR DESCRIPTION
When using the installer on certain basic terminals (like PuTTY), the TUI would display incorrectly with missing text or incorrect colors. This is down to the terminal reporting different `TERM` environment variable values, with the likes of PuTTY not fully advertising their capabilities through it. Who knew 🤷 !

This PR sets `TERM=xterm-256color` upon init.
