### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/workflows/check-typos.yml
+++ b/.github/workflows/check-typos.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Check for typos
-        uses: crate-ci/typos@v1.29.9
+        uses: crate-ci/typos@d2c5225afeda85a5abf7a567cdd01c3e329c8ccb # v1.29.9

--- a/.github/workflows/go-setup/action.yml
+++ b/.github/workflows/go-setup/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
       with:
         go-version: ${{ inputs.go-version }}
         cache: true 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Go Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Go
         uses: ./.github/workflows/go-setup
@@ -25,7 +25,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: test-results
           path: test.json
@@ -36,6 +36,6 @@ jobs:
     if: always()
     steps:
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
         with:
           name: test-results

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/workflows/go-setup
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6
         with:
           version: latest
           args: --timeout=10m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/workflows/go-setup
 
       - name: Release
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/shell-test.yml
+++ b/.github/workflows/shell-test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Shell Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       
       - name: Install bats
         run: |

--- a/.github/workflows/update-contributoor.yml
+++ b/.github/workflows/update-contributoor.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       pr_number: ${{ steps.cpr.outputs.pull-request-number }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ secrets.PANDA_OPS_BOT_PAT }}
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
           token: ${{ secrets.PANDA_OPS_BOT_PAT }}
           commit-message: "chore: update contributoor to ${{ github.event.client_payload.version }}"
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.update-pr.outputs.pr_number
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ secrets.PANDA_OPS_BOT_PAT }}
           fetch-depth: 0
@@ -88,7 +88,7 @@ jobs:
     needs: [wait-for-merge]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ secrets.PANDA_OPS_BOT_PAT }}
           fetch-depth: 0


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.