### PR TITLE
feat(validate): add support for 206 status code for beacon node validation

### DIFF
--- a/internal/validate/beacon.go
+++ b/internal/validate/beacon.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 )
@@ -49,7 +50,12 @@ func ValidateBeaconNodeAddress(addresses string) error {
 
 		defer resp.Body.Close()
 
-		if resp.StatusCode != http.StatusOK {
+		// Acceptable status codes are 200 and 206.
+		// 200 is the status code for a healthy beacon node.
+		// 206 is the status code for a beacon node that is syncing.
+		acceptableStatusCodes := []int{http.StatusOK, http.StatusPartialContent}
+
+		if !slices.Contains(acceptableStatusCodes, resp.StatusCode) {
 			lastErr = fmt.Errorf("beacon node %s returned status %d", address, resp.StatusCode)
 
 			continue

--- a/internal/validate/beacon_test.go
+++ b/internal/validate/beacon_test.go
@@ -33,7 +33,7 @@ func TestValidateBeaconNodeAddress(t *testing.T) {
 					w.WriteHeader(http.StatusOK)
 				})),
 				httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusOK)
+					w.WriteHeader(http.StatusPartialContent)
 				})),
 			},
 			wantErr: false,


### PR DESCRIPTION
The beacon node validation now accepts 206 status code as a valid response. This is because a beacon node that is syncing will return a 206 status code.