### PR TITLE
feat(install): add attestation data contribution opt-in page

### DIFF
--- a/cmd/cli/commands/install/display.go
+++ b/cmd/cli/commands/install/display.go
@@ -22,6 +22,7 @@ type InstallDisplay struct {
 	//nolint:unused // Disabled for now.
 	outputPage                  *OutputServerPage
 	outputServerCredentialsPage *OutputServerCredentialsPage
+	attestationOptInPage        *AttestationOptInPage
 	finishedPage                *FinishedPage
 }
 
@@ -38,11 +39,13 @@ func NewInstallDisplay(log *logrus.Logger, app *tview.Application, sidecarCfg si
 	display.welcomePage = NewWelcomePage(display)
 	display.beaconPage = NewBeaconNodePage(display)
 	display.outputServerCredentialsPage = NewOutputServerCredentialsPage(display)
+	display.attestationOptInPage = NewAttestationOptInPage(display)
 	display.finishedPage = NewFinishedPage(display)
 	display.installPages = []tui.PageInterface{
 		display.welcomePage,
 		display.beaconPage,
 		display.outputServerCredentialsPage,
+		display.attestationOptInPage,
 		display.finishedPage,
 	}
 
@@ -87,6 +90,7 @@ func (d *InstallDisplay) getCurrentStep() int {
 		"install-welcome":     1,
 		"install-beacon":      2,
 		"install-credentials": 3,
+		"install-attestation": 4,
 	}
 
 	currentPage, _ := d.pages.GetFrontPage()

--- a/cmd/cli/commands/install/page_50_output_server_credentials.go
+++ b/cmd/cli/commands/install/page_50_output_server_credentials.go
@@ -186,7 +186,7 @@ func validateAndSaveCredentials(p *OutputServerCredentialsPage) {
 
 	// Set initial focus on the Next button.
 	p.display.app.SetFocus(p.form.GetButton(0))
-	p.display.setPage(p.display.finishedPage.GetPage())
+	p.display.setPage(p.display.attestationOptInPage.GetPage())
 }
 
 func (p *OutputServerCredentialsPage) openErrorModal(err error) {

--- a/cmd/cli/commands/install/page_55_attestation_opt_in.go
+++ b/cmd/cli/commands/install/page_55_attestation_opt_in.go
@@ -1,0 +1,177 @@
+package install
+
+import (
+	"github.com/ethpandaops/contributoor-installer/internal/tui"
+	"github.com/ethpandaops/contributoor/pkg/config/v1"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// AttestationOptInPage is the page for opting into attestation data contribution.
+type AttestationOptInPage struct {
+	display *InstallDisplay
+	page    *tui.Page
+	content tview.Primitive
+	form    *tview.Form
+	enabled bool
+}
+
+// NewAttestationOptInPage creates a new AttestationOptInPage.
+func NewAttestationOptInPage(display *InstallDisplay) *AttestationOptInPage {
+	attestationPage := &AttestationOptInPage{
+		display: display,
+		enabled: false, // Default to opt-out
+	}
+
+	attestationPage.initPage()
+	attestationPage.page = tui.NewPage(
+		display.outputServerCredentialsPage.GetPage(),
+		"install-attestation",
+		"Attestation Data Contribution",
+		"Choose whether to contribute attestation data",
+		attestationPage.content,
+	)
+
+	return attestationPage
+}
+
+// GetPage returns the page.
+func (p *AttestationOptInPage) GetPage() *tui.Page {
+	return p.page
+}
+
+// initPage initializes the page.
+func (p *AttestationOptInPage) initPage() {
+	var (
+		modalWidth = 70
+		height     = 13
+	)
+
+	// We need a form to house our checkbox.
+	form := tview.NewForm()
+	form.SetButtonsAlign(tview.AlignCenter)
+	form.SetFieldBackgroundColor(tcell.ColorBlack)
+	form.SetBackgroundColor(tui.ColorFormBackground)
+	form.SetBorderPadding(0, 0, 0, 0)
+	form.SetLabelColor(tcell.ColorLightGray)
+	p.form = form
+
+	// Get existing value if any
+	if cfg := p.display.sidecarCfg.Get(); cfg.AttestationSubnetCheck != nil {
+		p.enabled = cfg.AttestationSubnetCheck.Enabled
+	}
+
+	// Add checkbox for attestation opt-in
+	form.AddCheckbox("Enable attestation data contribution", p.enabled, func(checked bool) {
+		p.enabled = checked
+	})
+
+	// Add a 'Next' button.
+	form.AddButton(tui.ButtonNext, func() {
+		p.saveAttestationPreference()
+	})
+
+	if button := form.GetButton(0); button != nil {
+		button.SetBackgroundColor(tview.Styles.PrimitiveBackgroundColor)
+		button.SetLabelColor(tcell.ColorLightGray)
+		form.SetButtonStyle(tcell.StyleDefault.
+			Background(tview.Styles.PrimitiveBackgroundColor).
+			Foreground(tcell.ColorLightGray))
+		form.SetButtonActivatedStyle(tcell.StyleDefault.
+			Background(tui.ColorButtonActivated).
+			Foreground(tcell.ColorBlack))
+	}
+
+	// Create text view with bandwidth information.
+	textView := tview.NewTextView()
+	textView.SetText(`Would you like to contribute attestation data?
+
+Contributing attestation data helps improve network analysis but will use a little more bandwidth.
+
+`)
+	textView.SetTextAlign(tview.AlignLeft)
+	textView.SetWordWrap(true)
+	textView.SetTextColor(tview.Styles.PrimaryTextColor)
+	textView.SetBackgroundColor(tui.ColorFormBackground)
+	textView.SetBorderPadding(0, 0, 2, 2)
+
+	// Create help text
+	helpText := tview.NewTextView()
+	helpText.SetText("[yellow]Tip: Press SPACE to toggle the checkbox[white]")
+	helpText.SetDynamicColors(true)
+	helpText.SetTextAlign(tview.AlignCenter)
+	helpText.SetBackgroundColor(tui.ColorFormBackground)
+
+	// Create a grid to control form alignment
+	formGrid := tview.NewGrid().
+		SetColumns(-1, -6, -1).
+		SetRows(0)
+	formGrid.SetBackgroundColor(tui.ColorFormBackground)
+	formGrid.AddItem(tview.NewBox().SetBackgroundColor(tui.ColorFormBackground), 0, 0, 1, 1, 0, 0, false)
+	formGrid.AddItem(form, 0, 1, 1, 1, 0, 0, true)
+	formGrid.AddItem(tview.NewBox().SetBackgroundColor(tui.ColorFormBackground), 0, 2, 1, 1, 0, 0, false)
+
+	// Create a flex container to stack text and form vertically.
+	flex := tview.NewFlex().
+		SetDirection(tview.FlexRow).
+		AddItem(textView, 4, 0, false).
+		AddItem(tview.NewBox().SetBackgroundColor(tui.ColorFormBackground), 1, 0, false). // Spacer between text and form
+		AddItem(formGrid, 3, 0, true).                                                    // Form grid with checkbox and button
+		AddItem(helpText, 1, 0, false).                                                   // Help text at bottom
+		AddItem(tview.NewBox().SetBackgroundColor(tui.ColorFormBackground), 1, 0, false)  // Bottom spacer
+
+	// Create content grid.
+	contentGrid := tview.NewGrid()
+	contentGrid.SetRows(1, 0, 0)
+	contentGrid.SetBackgroundColor(tui.ColorFormBackground)
+
+	// Add items to content grid.
+	contentGrid.AddItem(tview.NewBox().SetBackgroundColor(tui.ColorFormBackground), 0, 0, 1, 1, 0, 0, false)
+	contentGrid.AddItem(flex, 1, 0, 2, 1, 0, 0, true)
+	contentGrid.SetBorder(true)
+	contentGrid.SetTitle(" 📊 Attestation Data Contribution ")
+	contentGrid.SetBackgroundColor(tui.ColorFormBackground)
+
+	// Create border grid.
+	borderGrid := tview.NewGrid()
+	borderGrid.SetColumns(0, modalWidth, 0)
+	borderGrid.SetRows(0, height, 0, 2)
+	borderGrid.SetBackgroundColor(tui.ColorFormBackground)
+	borderGrid.AddItem(contentGrid, 1, 1, 1, 1, 0, 0, true)
+
+	p.content = borderGrid
+}
+
+func (p *AttestationOptInPage) saveAttestationPreference() {
+	// Update config with attestation preference
+	if err := p.display.sidecarCfg.Update(func(cfg *config.Config) {
+		if p.enabled {
+			// Only create the AttestationSubnetCheck if user opts in
+			if cfg.AttestationSubnetCheck == nil {
+				cfg.AttestationSubnetCheck = &config.AttestationSubnetCheck{}
+			}
+			cfg.AttestationSubnetCheck.Enabled = true
+		} else {
+			// Remove the field entirely for opt-out
+			cfg.AttestationSubnetCheck = nil
+		}
+	}); err != nil {
+		p.openErrorModal(err)
+
+		return
+	}
+
+	// Navigate to the finished page
+	p.display.app.SetFocus(p.form.GetButton(0))
+	p.display.setPage(p.display.finishedPage.GetPage())
+}
+
+func (p *AttestationOptInPage) openErrorModal(err error) {
+	p.display.app.SetRoot(tui.CreateErrorModal(
+		p.display.app,
+		err.Error(),
+		func() {
+			p.display.app.SetRoot(p.display.frame, true).EnableMouse(true)
+		},
+	), true).EnableMouse(true)
+}

--- a/cmd/cli/commands/install/page_60_finished.go
+++ b/cmd/cli/commands/install/page_60_finished.go
@@ -22,7 +22,7 @@ func NewFinishedPage(display *InstallDisplay) *FinishedPage {
 
 	finishedPage.initPage()
 	finishedPage.page = tui.NewPage(
-		display.outputServerCredentialsPage.GetPage(),
+		display.attestationOptInPage.GetPage(),
 		"install-finished",
 		"Installation Complete",
 		"Contributoor has been configured successfully",

--- a/cmd/cli/commands/status/status.go
+++ b/cmd/cli/commands/status/status.go
@@ -104,13 +104,17 @@ func showStatus(
 	fmt.Printf("%sContributoor Status%s\n", tui.TerminalColorLightBlue, tui.TerminalColorReset)
 	fmt.Printf("%-20s: %s\n", "Version", current)
 	fmt.Printf("%-20s: %s\n", "Run Method", cfg.RunMethod)
-	fmt.Printf("%-20s: %s\n", "Network", cfg.NetworkName)
 	fmt.Printf("%-20s: %s\n", "Beacon Node", cfg.BeaconNodeAddress)
 	fmt.Printf("%-20s: %s\n", "Config Path", sidecarCfg.GetConfigPath())
 
 	if cfg.OutputServer != nil {
 		fmt.Printf("%-20s: %s\n", "Output Server", cfg.OutputServer.Address)
 	}
+
+	fmt.Printf(
+		"%-20s: %v\n", "Opt-in Attestations",
+		cfg.AttestationSubnetCheck != nil && cfg.AttestationSubnetCheck.Enabled,
+	)
 
 	// Print running status with color.
 	statusColor := tui.TerminalColorRed

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -59,12 +59,49 @@ func UpgradeWarning(currentVersion string, latestVersion string) {
 		return
 	}
 
-	fmt.Printf(
-		"%sYou are running an old version of contributoor; we suggest you to update it to the latest version, '%s%s%s'. You can manually upgrade by running 'contributoor update'.%s\n\n",
-		TerminalColorYellow,
+	// Fixed box width
+	boxWidth := 78
+
+	// Create the warning message parts
+	line1 := "You are running an old version of contributoor;"
+	line3 := "You can manually upgrade by running 'contributoor update'."
+
+	// Print the box
+	fmt.Printf("\n%s╔%s╗\n", TerminalColorYellow, strings.Repeat("═", boxWidth))
+	fmt.Printf("║%s║\n", strings.Repeat(" ", boxWidth))
+
+	// Center and print each line
+	fmt.Printf("║%s║\n", centerText(line1, boxWidth))
+
+	// Print the version line with color
+	versionPrefix := "we suggest you to update it to the latest version, '"
+	versionSuffix := "'."
+	totalLen := len(versionPrefix) + len(latestVersion) + len(versionSuffix)
+	leftPad := (boxWidth - totalLen) / 2
+	rightPad := boxWidth - totalLen - leftPad
+
+	fmt.Printf("║%s%s%s%s%s%s%s║\n",
+		strings.Repeat(" ", leftPad),
+		versionPrefix,
 		TerminalColorLightBlue,
 		latestVersion,
 		TerminalColorYellow,
-		TerminalColorReset,
-	)
+		versionSuffix,
+		strings.Repeat(" ", rightPad))
+
+	fmt.Printf("║%s║\n", centerText(line3, boxWidth))
+
+	fmt.Printf("║%s║\n", strings.Repeat(" ", boxWidth))
+	fmt.Printf("╚%s╝%s\n\n", strings.Repeat("═", boxWidth), TerminalColorReset)
+}
+
+// centerText centers text within a given width.
+func centerText(text string, width int) string {
+	if len(text) >= width {
+		return text[:width]
+	}
+
+	padding := (width - len(text)) / 2
+
+	return fmt.Sprintf("%s%s%s", strings.Repeat(" ", padding), text, strings.Repeat(" ", width-len(text)-padding))
 }


### PR DESCRIPTION
Introduce a new wizard page that lets users decide whether to share attestation data. The checkbox defaults to disabled (opt-out) and persists the choice into the sidecar configuration.

<img width="967" height="594" alt="Screenshot 2025-07-21 at 15 29 15" src="https://github.com/user-attachments/assets/d064b198-5e90-47c9-a09f-3a2b3cbe2c88" />

